### PR TITLE
Onglet non fonctionnel 

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -36,8 +36,7 @@ website:
           - torch_Python_regression.qmd
           - Intel_MKL.qmd
           - torch_and_rcpp.qmd
-          - text: Introduction à JAX
-            href: jax-getting-started.qmd
+          - jax-getting-started.qmd
           - jit-example-pln.md
       - text: Autour de PLN
         menu: 


### PR DESCRIPTION
Fix #33 Onglet non fonctionnel dans la partie 'programmation efficace' (la page de @HGangloff n'est pas disponible en version html)
Simplification de la partie du yaml décrivant cet onglet (toutes les pages sont affichées avec le même format). 